### PR TITLE
Fix branch ref in update action.

### DIFF
--- a/.github/workflows/update-from-api.yml
+++ b/.github/workflows/update-from-api.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: 'revitalize'
+          ref: 'develop'
           token: ${{ secrets.PAT_REPO }}
 
       # Execute custom action which fetches data from the GitHub API and updates the data files


### PR DESCRIPTION
Checkout branch ref was still set to `revitalize` in the `update-from-api.yml` workflow, causing the update job to fail. This PR should fix the issue.